### PR TITLE
Changed sudo solbuild update unstable-x86-64

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The `-u` flag will automatically update the image.
     sudo solbuild update
 
     # Update a specific profile
-    sudo solbuild update unstable-x86-64
+    sudo solbuild update unstable-x86_64
 
 **Building packages**
 


### PR DESCRIPTION
I changed it to sudo solbuild update unstable-x86_64 because when you try to update with unstable-x86-64, it gives you an error saying

Error: 'unstable-x86-64' is not a known profile
Valid profiles include:

* main-x86_64
* unstable-x86_64