### PR TITLE
data: Provide a local repo configuration

### DIFF
--- a/data/local-unstable-x86_64.profile
+++ b/data/local-unstable-x86_64.profile
@@ -1,0 +1,33 @@
+#
+# local-unstable-x86_64 configuration
+#
+# Build Solus packages using the unstable repository image.
+# This is the default profile for the Solus build server and developers.
+#
+# Do not make changes to this file. solbuild is implemented in a stateless
+# fashion, and will load files in a layered mechanism. If you wish to edit
+# this profile, copy to /etc/solbuild/.
+#
+# It is generally advisable to create a *new* profile name in /etc, because
+# we will load /etc/ before /usr/share. Thus, profiles with the same name
+# in /etc/ are loaded *first* and will override this profile.
+#
+# Of course, if that's what you intended to do, then by all means, do so.
+
+image = "unstable-x86_64"
+
+# If you have a local repo providing packages that exist in the main
+# repository already, you should remove the repo, and re-add it *after*
+# your local repository:
+remove_repos = ['Solus']
+add_repos = ['Local','Solus']
+
+# A local repo with automatic indexing
+[repo.Local]
+uri = "/var/lib/solbuild/local"
+local = true
+autoindex = true
+
+# Re-add the Solus unstable repo
+[repo.Solus]
+uri = "https://packages.solus-project.com/unstable/eopkg-index.xml.xz"


### PR DESCRIPTION
This allows for the easy (and standardised) set up for using local
packages with solbuild.

So as discussed I see this as 3 simple steps (which I can handle):
1. Repackage solbuild with this profile + tmpfiles.d 'solbuild-local.conf' to create the dir (both in solbuild-config-local-unstable).
2. Create a 'make local' in common to cover a make replacement i.e. 
local:
    sudo solbuild build $(SPECFILE) -p local-unstable-x86_64;
    make abireport
3. Document this is the Help Center
i.e. to use non repo eopkg's in solbuild, install solbuild-config-local-unstable, put your eopkg's in /var/lib/solbuild/local, run `make local` instead of make

Think that would cover #4 well