### PR TITLE
Ensure we pass recursive in order to clone any submodules of other submodules.

### DIFF
--- a/src/builder/source/git.go
+++ b/src/builder/source/git.go
@@ -256,7 +256,7 @@ func (g *GitSource) resetOnto(repo *git.Repository, ref string) error {
 // reset has taken place.
 func (g *GitSource) submodules() error {
 	// IDK What else to tell ya, git2go submodules is broken
-	cmd := []string{"submodule", "update", "--init"}
+	cmd := []string{"submodule", "update", "--init", "--recursive"}
 	return commands.ExecStdoutArgsDir(g.ClonePath, "git", cmd)
 }
 


### PR DESCRIPTION
**Example case:** [yubioath-desktop](https://github.com/Yubico/yubioath-desktop/)

yubioath-desktop uses a submodule called `yubikey-manager`. This submodule has its own submodule, `yubicommon`. `yubicommon` will not clone prior to this PR. While this typically wouldn't be an issue, since you could just clone the submodule recursively during setup, yubicommon symlinks `ykman/yubicommon` to the submodule and as a result, the cloning seems to fall on its face.