### PR TITLE
change locales to en_US.utf8

### DIFF
--- a/src/builder/util.go
+++ b/src/builder/util.go
@@ -151,8 +151,8 @@ func TouchFile(path string) error {
 func SaneEnvironment(username, home string) []string {
 	environment := []string{
 		"PATH=/usr/bin:/usr/sbin:/bin/:/sbin",
-		"LANG=C",
-		"LC_ALL=C",
+		"LANG=en_US.utf8",
+		"LC_ALL=en_US.utf8",
 		fmt.Sprintf("HOME=%s", home),
 		fmt.Sprintf("USER=%s", username),
 		fmt.Sprintf("USERNAME=%s", username),


### PR DESCRIPTION
To resolve such problems (encountered with meson):
```
WARNING: You are using 'ANSI_X3.4-1968' which is not a a Unicode-compatible locale.
WARNING: You might see errors if you use UTF-8 strings as filenames, as strings, or as file contents.
WARNING: Please switch to a UTF-8 locale for your platform.
```
