### PR TITLE
Use net/http instead of curl to download image

### DIFF
--- a/src/solbuild/cmd/init.go
+++ b/src/solbuild/cmd/init.go
@@ -74,7 +74,7 @@ func doInit(manager *builder.Manager) {
 
 	// Now ensure we actually have said image
 	if !bk.IsFetched() {
-		downloadImage(bk, false)
+		downloadImage(bk)
 	}
 
 	// Decompress the image
@@ -96,7 +96,7 @@ func doInit(manager *builder.Manager) {
 }
 
 // Downloads an image using net/http.
-func downloadImage(bk *builder.BackingImage, progressBar bool) (err error) {
+func downloadImage(bk *builder.BackingImage) (err error) {
 	file, err := os.Create(bk.ImagePathXZ)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/src/solbuild/cmd/init.go
+++ b/src/solbuild/cmd/init.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/cheggaaa/pb"
 	"github.com/solus-project/libosdev/commands"
 	"github.com/spf13/cobra"
 )
@@ -124,11 +125,17 @@ func downloadImage(bk *builder.BackingImage, progressBar bool) (err error) {
 
 	defer resp.Body.Close()
 
+	bar := pb.New64(resp.ContentLength).SetUnits(pb.U_BYTES)
+	reader := bar.NewProxyReader(resp.Body)
+	bar.ShowSpeed = true
+	bar.Start()
+	defer bar.Finish()
+
 	bytesRemaining := resp.ContentLength
 	done := false
 	buf := make([]byte, 32*1024)
 	for !done {
-		bytesRead, err := resp.Body.Read(buf)
+		bytesRead, err := reader.Read(buf)
 		if err == io.EOF {
 			done = true
 		} else if err != nil {


### PR DESCRIPTION
Switches the `init` subcommand to use `net/http` to download the image. Includes download progress bar.